### PR TITLE
fix: update Angular build budgets for Firebase deployment

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -76,8 +76,13 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "12kB"
+                  "maximumWarning": "15kB",
+                  "maximumError": "25kB"
+                },
+                {
+                  "type": "all",
+                  "maximumWarning": "3mb",
+                  "maximumError": "5mb"
                 }
               ],
               "outputHashing": "all",


### PR DESCRIPTION
- Increase anyComponentStyle budget from 6kB/12kB to 15kB/25kB
- Add 'all' budget type with 3mb/5mb limits for overall bundle size
- Fix Firebase deployment bundle size errors caused by new mobile POS components
- Ensure production builds can accommodate enhanced mobile interface CSS